### PR TITLE
fix issue with backoff decorator not working when function uses yield

### DIFF
--- a/tap_amazon_sp/streams.py
+++ b/tap_amazon_sp/streams.py
@@ -258,7 +258,7 @@ class OrdersStream(IncrementalStream):
                                 for item in response.payload['Orders'])
                     continue
 
-                yield from response.payload['Orders']
+                return response.payload['Orders']
 
 
 class OrderItems(IncrementalStream):
@@ -294,7 +294,7 @@ class OrderItems(IncrementalStream):
 
                 order_items = flatten_order_items(response, date)
 
-                yield from order_items
+                return order_items
 
 
 class SalesStream(IncrementalStream):
@@ -339,7 +339,7 @@ class SalesStream(IncrementalStream):
                 for record in response.payload:
                     record.update({'retrieved': end_date})
 
-                yield from response.payload
+                return response.payload
 
 
 STREAMS = {


### PR DESCRIPTION
Backoff decorator does not work when using a `yield` instead of a `return` statement. Changed `yield` statements to `return` statements instead.

# Description of change
(write a short description or paste a link to JIRA)

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
