### PR TITLE
Refactor API calls to fix logic bug

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -6,6 +6,6 @@
   "aws_secret_key": "abc123",
   "role_arn": "arn:aws:iam::123456:role/some_role",
   "start_date": "2021-08-03T16:41:14+00:00",
-  "marketplace": "GB",
+  "marketplaces": "GB US",
   "sales_data_granularity": "HOUR"
 }

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,8 @@ setup(
     py_modules=["tap_amazon_sp"],
     install_requires=[
         'backoff==1.8.0',
-        'singer-python==5.10.0',
-        'python-amazon-sp-api==0.5.3'
+        'singer-python==5.12.2',
+        'python-amazon-sp-api==0.12.4'
     ],
     entry_points="""
     [console_scripts]

--- a/tap_amazon_sp/helpers.py
+++ b/tap_amazon_sp/helpers.py
@@ -61,7 +61,7 @@ def flatten_order_items(response: dict, date_to_add: str) -> List[dict]:
     order_items = []
     amazon_order_id = response.get("AmazonOrderId")
 
-    for order_item in response['OrderItems']:
+    for order_item in response.get('OrderItems', []):
         order_item['AmazonOrderId'] = amazon_order_id
         order_item['OrderLastUpdateDate'] = date_to_add
         order_items.append(order_item)

--- a/tap_amazon_sp/streams.py
+++ b/tap_amazon_sp/streams.py
@@ -212,7 +212,7 @@ class FullTableStream(BaseStream):
 
 class OrdersStream(IncrementalStream):
     """
-    Gets records for a sample stream.
+    Gets records for orders stream.
     """
     tap_stream_id = 'orders'
     key_properties = ['AmazonOrderId']
@@ -224,6 +224,8 @@ class OrdersStream(IncrementalStream):
     @backoff.on_exception(backoff.expo,
                           SellingApiRequestThrottledException,
                           max_tries=3,
+                          base=3,
+                          factor=20,
                           on_backoff=log_backoff)
     def get_orders(client, start_date, next_token, timer):
 
@@ -264,6 +266,9 @@ class OrdersStream(IncrementalStream):
 
 
 class OrderItems(IncrementalStream):
+    """
+    Gets records for order items stream.
+    """
     tap_stream_id = 'order_items'
     key_properties = ['AmazonOrderId', 'OrderItemId']
     replication_key = 'OrderLastUpdateDate'
@@ -274,6 +279,8 @@ class OrderItems(IncrementalStream):
     @backoff.on_exception(backoff.expo,
                           SellingApiRequestThrottledException,
                           max_tries=3,
+                          base=3,
+                          factor=5,
                           on_backoff=log_backoff)
     def get_order_items(client: Orders, order_id: str):
         return client.get_order_items(order_id=order_id).payload
@@ -300,6 +307,9 @@ class OrderItems(IncrementalStream):
 
 
 class SalesStream(IncrementalStream):
+    """
+    Gets records for sales stream.
+    """
     tap_stream_id = 'sales'
     key_properties = ['interval']
     replication_key = 'retrieved'

--- a/tests/unittests/test_get_orders_backoff.py
+++ b/tests/unittests/test_get_orders_backoff.py
@@ -1,0 +1,39 @@
+from unittest import TestCase, mock
+
+from sp_api.base.exceptions import SellingApiRequestThrottledException
+
+import tap_amazon_sp
+
+
+CONFIG = {
+  "refresh_token": "Atzr|abc123",
+  "client_id": "amzn123",
+  "client_secret": "abcde",
+  "aws_access_key": "ABCDE",
+  "aws_secret_key": "abc123",
+  "role_arn": "arn:aws:iam::123456:role/some_role",
+  "start_date": "2021-08-03T16:41:14+00:00",
+  "marketplaces": "GB US",
+  "sales_data_granularity": "HOUR"
+}
+
+@mock.patch('tap_amazon_sp.streams.OrdersStream.get_orders')
+class TestBackoff(TestCase):
+
+    def test_request_backoff_on_retry_error(self, mock_get_orders):
+        start_date = CONFIG.get('start_date')
+
+        mock_get_orders.side_effect = SellingApiRequestThrottledException(
+            [{
+                'message': 'You exceeded your quota for the requested resource.',
+                'code': 'QuotaExceeded'
+            }])
+
+        with self.assertRaises(SellingApiRequestThrottledException):
+
+            response = tap_amazon_sp.streams.OrdersStream.get_orders(
+                client=None,
+                start_date=start_date,
+                next_token=None,
+                timer=None
+            )


### PR DESCRIPTION
# Description of change

I recently submitted PR #4 to fix an issue where the `backoff` decorator was not working properly as the function it was decorating used `yield` instead of `return`. The problem was that the error would be thrown but not caught by the `backoff` decorator as the function would still `yield` a result and eventually throw a tap-level exception, outside the scope of the decorator. I refactored the function to simply use `return` so that the error would be thrown and caught by decorator. This worked, but it caused a logic bug I didn't consider where the tap would `return` early and not stream all the data from an endpoint.

To fix the issue, I changed the function back to using `yield` instead of `return` and refactored the actual API call into its own function which I decorated with `backoff`. This now provides the correct behavior of backing off on 429 errors as well as streaming all of the data returned by the API.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
