### PR TITLE
Improve bookmarking strategy and adjust backoff

### DIFF
--- a/tap_amazon_sp/streams.py
+++ b/tap_amazon_sp/streams.py
@@ -223,7 +223,7 @@ class OrdersStream(IncrementalStream):
     @lru_cache
     @backoff.on_exception(backoff.expo,
                           SellingApiRequestThrottledException,
-                          max_tries=3,
+                          max_tries=5,
                           base=3,
                           factor=20,
                           on_backoff=log_backoff)
@@ -278,9 +278,9 @@ class OrderItems(IncrementalStream):
     @staticmethod
     @backoff.on_exception(backoff.expo,
                           SellingApiRequestThrottledException,
-                          max_tries=3,
+                          max_tries=5,
                           base=3,
-                          factor=5,
+                          factor=10,
                           on_backoff=log_backoff)
     def get_order_items(client: Orders, order_id: str):
         return client.get_order_items(order_id=order_id).payload

--- a/tap_amazon_sp/streams.py
+++ b/tap_amazon_sp/streams.py
@@ -176,6 +176,9 @@ class IncrementalStream(BaseStream):
                         counter.increment()
                         max_record_value = record_replication_value.isoformat()
 
+                        state = singer.write_bookmark(state, self.tap_stream_id, marketplace.name, {self.replication_key: max_record_value})
+                        singer.write_state(state)
+
             state = singer.write_bookmark(state, self.tap_stream_id, marketplace.name, {self.replication_key: max_record_value})
             singer.write_state(state)
         return state


### PR DESCRIPTION
# Description of change
- adjusted backoff to increase `max_retries` for `orders` and `order_items` streams
-  increased `factor` for `order_items` stream to wait longer on each backoff attempt
- added writing bookmark for every record written to handle failed runs gracefully on the next run

# Manual QA steps
 - ran tap locally
 - ran with `singer-check-tap`
 - ran with `target-stitch`
 
# Risks
 - minimal, no new functionality is introduced
 
# Rollback steps
 - revert this branch
